### PR TITLE
웹뷰 페이지, 이미지 업로드 페이지 로직 구현 완료

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -5,6 +5,7 @@ import {createNativeStackNavigator} from '@react-navigation/native-stack';
 import LandingPage from './src/pages/Landingpage';
 import CameraPage from './src/pages/Camerapage';
 import ScreenshotPage from './src/pages/Screenshotpage';
+import UploadImagePage from './src/pages/Uploadimagepage';
 
 // React Navigation TS docs: https://reactnavigation.org/docs/typescript/
 export type NavParamType = {
@@ -43,6 +44,11 @@ const BottomTabNav = () => {
         name="Screenshot"
         options={{headerShown: false}}
         component={ScreenshotPage}
+      />
+      <Tab.Screen
+        name="Uploadimage"
+        options={{headerShown: false}}
+        component={UploadImagePage}
       />
     </Tab.Navigator>
   );

--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@
 - react-native-voice/voice: ^3.2.4
 - react-native-fs: ^2.20.0
 - react-native-webview: ^13.10.5
+- react-native-view-shot: ^3.8.0
+- react-native-image-crop-picker: ^0.41.2
+- react-native-sound: ^0.11.2
+
 - axios: ^1.7.2
 
 ---
@@ -63,9 +67,29 @@
 - [React Navigation과 TS 동시 사용 공식문서](https://reactnavigation.org/docs/typescript/)
 - [React Navigation과 TS 동시 사용 블로그](https://velog.io/@hokim/react-native-2.-%ED%8E%98%EC%9D%B4%EC%A7%80-%EC%9D%B4%EB%8F%99-feat.-tailwind#3-2-%EB%84%A4%EC%9D%B4%ED%8B%B0%EB%B8%8C-%EC%8A%A4%ED%83%9D-%EB%84%A4%EB%B9%84%EA%B2%8C%EC%9D%B4%ED%84%B0)
 
-#### 음성 인식을 통해 챗봇을 사용하도록 하기 위한 react-native-voice/voice 라이브러리
+#### 음성 인식 STT를 통해 챗봇을 사용하도록 하기 위한 react-native-voice/voice 라이브러리
 
 - [공식 Github](https://github.com/react-native-voice/voice)
 - [참고 블로그](https://deku.posstree.com/ko/react-native/react-native-voice/)
+
+#### 앱 내에서 웹브라우징을 할 수 있도록 하기 위한 react-native-webview 라이브러리
+
+- [공식 Github](https://github.com/react-native-webview/react-native-webview)
+
+#### 웹뷰 컴포넌트를 캡쳐하기 위한 react-native-view-shot 라이브러리
+
+- [공식 Github](https://github.com/gre/react-native-view-shot)
+
+#### 파일 경로를 사용해서 이미지를 불러오고, Base64로 인코딩하기 위한 react-native-fs 라이브러리
+
+- [공식 Github](https://github.com/itinance/react-native-fs)
+
+#### TTS 음성인 mp3 파일을 재생하기 위한 react-native-sound 라이브러리
+
+- [공식 Github](https://github.com/zmxv/react-native-sound)
+
+#### 갤러리에서 이미지를 불러오기 위한 react-native-image-crop-picker 라이브러리
+
+- [공식 Github](https://github.com/ivpusic/react-native-image-crop-picker)
 
 ---

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -77,6 +77,8 @@ android {
     namespace "com.iseeyou"
     defaultConfig {
         applicationId "com.iseeyou"
+        // react-native-image-crop-picker
+        vectorDrawables.useSupportLibrary = true
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES"/>
 
     <application
       android:name=".MainApplication"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -10,6 +10,9 @@ buildscript {
     repositories {
         google()
         mavenCentral()
+        // react-native-image-crop-picker
+        maven { url 'https://maven.google.com' }
+        maven { url "https://www.jitpack.io" }
     }
     dependencies {
         classpath("com.android.tools.build:gradle")

--- a/ios/Iseeyou.xcodeproj/project.pbxproj
+++ b/ios/Iseeyou.xcodeproj/project.pbxproj
@@ -222,6 +222,7 @@
 			knownRegions = (
 				en,
 				Base,
+				ko,
 			);
 			mainGroup = 83CBB9F61A601CBA00E9B192;
 			productRefGroup = 83CBBA001A601CBA00E9B192 /* Products */;
@@ -592,10 +593,7 @@
 					"-DFOLLY_CFG_NO_COROUTINES=1",
 					"-DFOLLY_HAVE_CLOCK_GETTIME=1",
 				);
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					" ",
-				);
+				OTHER_LDFLAGS = "$(inherited)  ";
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
 				USE_HERMES = true;
@@ -667,10 +665,7 @@
 					"-DFOLLY_CFG_NO_COROUTINES=1",
 					"-DFOLLY_HAVE_CLOCK_GETTIME=1",
 				);
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					" ",
-				);
+				OTHER_LDFLAGS = "$(inherited)  ";
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
 				USE_HERMES = true;

--- a/ios/Iseeyou/Info.plist
+++ b/ios/Iseeyou/Info.plist
@@ -54,5 +54,7 @@
   	<string>$(PRODUCT_NAME) needs access to your Microphone</string>
   	<key>NSSpeechRecognitionUsageDescription</key>
   	<string>$(PRODUCT_NAME) needs access to your speech recognition</string>
+	<key>NSPhotoLibraryUsageDescription</key>
+  	<string>$(PRODUCT_NAME) needs access to your Gallary</string>
 </dict>
 </plist>

--- a/ios/Iseeyou/PrivacyInfo.xcprivacy
+++ b/ios/Iseeyou/PrivacyInfo.xcprivacy
@@ -9,6 +9,7 @@
 			<string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
 			<key>NSPrivacyAccessedAPITypeReasons</key>
 			<array>
+				<string>3B52.1</string>
 				<string>C617.1</string>
 			</array>
 		</dict>

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1197,6 +1197,15 @@ PODS:
     - React-utils (= 0.74.3)
   - RNFS (2.20.0):
     - React-Core
+  - RNImageCropPicker (0.41.2):
+    - React-Core
+    - React-RCTImage
+    - RNImageCropPicker/QBImagePickerController (= 0.41.2)
+    - TOCropViewController (~> 2.7.4)
+  - RNImageCropPicker/QBImagePickerController (0.41.2):
+    - React-Core
+    - React-RCTImage
+    - TOCropViewController (~> 2.7.4)
   - RNScreens (3.32.0):
     - DoubleConversion
     - glog
@@ -1225,6 +1234,7 @@ PODS:
   - RNSound/Core (0.11.2):
     - React-Core
   - SocketRocket (0.7.0)
+  - TOCropViewController (2.7.4)
   - VisionCamera (4.4.1):
     - VisionCamera/Core (= 4.4.1)
     - VisionCamera/React (= 4.4.1)
@@ -1295,6 +1305,7 @@ DEPENDENCIES:
   - React-utils (from `../node_modules/react-native/ReactCommon/react/utils`)
   - ReactCommon/turbomodule/core (from `../node_modules/react-native/ReactCommon`)
   - RNFS (from `../node_modules/react-native-fs`)
+  - RNImageCropPicker (from `../node_modules/react-native-image-crop-picker`)
   - RNScreens (from `../node_modules/react-native-screens`)
   - RNSound (from `../node_modules/react-native-sound`)
   - VisionCamera (from `../node_modules/react-native-vision-camera`)
@@ -1304,6 +1315,7 @@ SPEC REPOS:
   trunk:
     - Mute
     - SocketRocket
+    - TOCropViewController
 
 EXTERNAL SOURCES:
   boost:
@@ -1425,6 +1437,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon"
   RNFS:
     :path: "../node_modules/react-native-fs"
+  RNImageCropPicker:
+    :path: "../node_modules/react-native-image-crop-picker"
   RNScreens:
     :path: "../node_modules/react-native-screens"
   RNSound:
@@ -1495,9 +1509,11 @@ SPEC CHECKSUMS:
   React-utils: a06061b3887c702235d2dac92dacbd93e1ea079e
   ReactCommon: f00e436b3925a7ae44dfa294b43ef360fbd8ccc4
   RNFS: 4ac0f0ea233904cb798630b3c077808c06931688
+  RNImageCropPicker: 771e2ca319d2cf92e04ebf334ece892ee9a6728f
   RNScreens: 5aeecbb09aa7285379b6e9f3c8a3c859bb16401c
   RNSound: 6c156f925295bdc83e8e422e7d8b38d33bc71852
   SocketRocket: abac6f5de4d4d62d24e11868d7a2f427e0ef940d
+  TOCropViewController: 80b8985ad794298fb69d3341de183f33d1853654
   VisionCamera: 21e2ec4cda0955d40589e939042af275e149dbf9
   Yoga: 04f1db30bb810187397fa4c37dd1868a27af229c
 

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -938,6 +938,8 @@ PODS:
     - React-debug
   - react-native-safe-area-context (4.10.7):
     - React-Core
+  - react-native-view-shot (3.8.0):
+    - React-Core
   - react-native-voice (3.2.4):
     - React-Core
   - react-native-volume-manager (1.10.0):
@@ -1260,6 +1262,7 @@ DEPENDENCIES:
   - React-logger (from `../node_modules/react-native/ReactCommon/logger`)
   - React-Mapbuffer (from `../node_modules/react-native/ReactCommon`)
   - react-native-safe-area-context (from `../node_modules/react-native-safe-area-context`)
+  - react-native-view-shot (from `../node_modules/react-native-view-shot`)
   - "react-native-voice (from `../node_modules/@react-native-voice/voice`)"
   - react-native-volume-manager (from `../node_modules/react-native-volume-manager`)
   - react-native-webview (from `../node_modules/react-native-webview`)
@@ -1360,6 +1363,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon"
   react-native-safe-area-context:
     :path: "../node_modules/react-native-safe-area-context"
+  react-native-view-shot:
+    :path: "../node_modules/react-native-view-shot"
   react-native-voice:
     :path: "../node_modules/@react-native-voice/voice"
   react-native-volume-manager:
@@ -1454,6 +1459,7 @@ SPEC CHECKSUMS:
   React-logger: fa92ba4d3a5d39ac450f59be2a3cec7b099f0304
   React-Mapbuffer: 9f68550e7c6839d01411ac8896aea5c868eff63a
   react-native-safe-area-context: 422017db8bcabbada9ad607d010996c56713234c
+  react-native-view-shot: 6b7ed61d77d88580fed10954d45fad0eb2d47688
   react-native-voice: f5e8eec2278451d0017eb6a30a6ccc726aca34e0
   react-native-volume-manager: 3c7d8047841b6831730dea7bf25250522388b4f4
   react-native-webview: 553abd09f58e340fdc7746c9e2ae096839e99911

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1219,6 +1219,11 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
+  - RNSound (0.11.2):
+    - React-Core
+    - RNSound/Core (= 0.11.2)
+  - RNSound/Core (0.11.2):
+    - React-Core
   - SocketRocket (0.7.0)
   - VisionCamera (4.4.1):
     - VisionCamera/Core (= 4.4.1)
@@ -1291,6 +1296,7 @@ DEPENDENCIES:
   - ReactCommon/turbomodule/core (from `../node_modules/react-native/ReactCommon`)
   - RNFS (from `../node_modules/react-native-fs`)
   - RNScreens (from `../node_modules/react-native-screens`)
+  - RNSound (from `../node_modules/react-native-sound`)
   - VisionCamera (from `../node_modules/react-native-vision-camera`)
   - Yoga (from `../node_modules/react-native/ReactCommon/yoga`)
 
@@ -1421,6 +1427,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native-fs"
   RNScreens:
     :path: "../node_modules/react-native-screens"
+  RNSound:
+    :path: "../node_modules/react-native-sound"
   VisionCamera:
     :path: "../node_modules/react-native-vision-camera"
   Yoga:
@@ -1488,6 +1496,7 @@ SPEC CHECKSUMS:
   ReactCommon: f00e436b3925a7ae44dfa294b43ef360fbd8ccc4
   RNFS: 4ac0f0ea233904cb798630b3c077808c06931688
   RNScreens: 5aeecbb09aa7285379b6e9f3c8a3c859bb16401c
+  RNSound: 6c156f925295bdc83e8e422e7d8b38d33bc71852
   SocketRocket: abac6f5de4d4d62d24e11868d7a2f427e0ef940d
   VisionCamera: 21e2ec4cda0955d40589e939042af275e149dbf9
   Yoga: 04f1db30bb810187397fa4c37dd1868a27af229c

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "react-native-fs": "^2.20.0",
     "react-native-safe-area-context": "^4.10.7",
     "react-native-screens": "^3.32.0",
+    "react-native-sound": "^0.11.2",
     "react-native-view-shot": "^3.8.0",
     "react-native-vision-camera": "^4.4.1",
     "react-native-volume-manager": "^1.10.0",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "react-native-fs": "^2.20.0",
     "react-native-safe-area-context": "^4.10.7",
     "react-native-screens": "^3.32.0",
+    "react-native-view-shot": "^3.8.0",
     "react-native-vision-camera": "^4.4.1",
     "react-native-volume-manager": "^1.10.0",
     "react-native-webview": "^13.10.5"

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "react": "18.2.0",
     "react-native": "0.74.3",
     "react-native-fs": "^2.20.0",
+    "react-native-image-crop-picker": "^0.41.2",
     "react-native-safe-area-context": "^4.10.7",
     "react-native-screens": "^3.32.0",
     "react-native-sound": "^0.11.2",

--- a/src/apis/poststttext.ts
+++ b/src/apis/poststttext.ts
@@ -1,18 +1,53 @@
 import axios from 'axios';
+import Sound from 'react-native-sound';
 import {API_URL} from '../utils/apiurl';
 
 interface Props {
-  recognizedText: string;
-  setAiSttResult: React.Dispatch<React.SetStateAction<string>>;
+  reqText: string;
+  prevAnswer: string;
+  setPrevAnswer: React.Dispatch<React.SetStateAction<string>>;
 }
 
-export const postSttText = ({recognizedText, setAiSttResult}: Props) => {
-  //   axios
-  //     .post(API_URL, recognizedText)
-  //     .then(res => setAiSttResult(res.data))
-  //     .catch(e => console.error(e));
+interface Response {
+  data: {
+    msg: string;
+    mp3: string;
+  };
+}
 
-  setTimeout(() => {
-    setAiSttResult('stt 응답 완료');
-  }, 1000);
+export const postSttText = ({reqText, prevAnswer, setPrevAnswer}: Props) => {
+  if (prevAnswer === '') {
+    console.log(
+      'prevAnswer가 비어있어 postSttText 함수를 early return 합니다.',
+    );
+    return;
+  }
+
+  axios
+    .post(API_URL + '/voice', {
+      reqText: reqText,
+      prevText: prevAnswer,
+    })
+    .then((res: Response) => {
+      const {msg, mp3} = res.data;
+      console.log('msg: ', msg, ' mp3: ', mp3);
+      setPrevAnswer(msg);
+
+      const ttsMp3 = new Sound(`${API_URL}${mp3}`, undefined, error => {
+        if (error) {
+          console.log('Error loading sound: ' + error);
+
+          return;
+        }
+        ttsMp3.play(success => {
+          if (success) {
+            console.log('성공적으로 재생되었습니다.');
+            ttsMp3.release();
+          } else {
+            console.log('재생 중 오류가 발생했습니다.');
+          }
+        });
+      });
+    })
+    .catch(error => console.error(error));
 };

--- a/src/apis/poststttext.ts
+++ b/src/apis/poststttext.ts
@@ -5,6 +5,7 @@ import {API_URL} from '../utils/apiurl';
 interface Props {
   reqText: string;
   prevAnswer: string;
+  prevBase64Img: string;
   setPrevAnswer: React.Dispatch<React.SetStateAction<string>>;
 }
 
@@ -15,7 +16,12 @@ interface Response {
   };
 }
 
-export const postSttText = ({reqText, prevAnswer, setPrevAnswer}: Props) => {
+export const postSttText = ({
+  reqText,
+  prevAnswer,
+  prevBase64Img,
+  setPrevAnswer,
+}: Props) => {
   if (prevAnswer === '') {
     console.log(
       'prevAnswer가 비어있어 postSttText 함수를 early return 합니다.',
@@ -25,8 +31,13 @@ export const postSttText = ({reqText, prevAnswer, setPrevAnswer}: Props) => {
 
   axios
     .post(API_URL + '/voice', {
-      reqText: reqText,
-      prevText: prevAnswer,
+      voiceInput: {
+        reqText: reqText,
+        prevText: prevAnswer,
+      },
+      imageInput: {
+        image: prevBase64Img,
+      },
     })
     .then((res: Response) => {
       const {msg, mp3} = res.data;

--- a/src/hooks/usecamerapostimg.ts
+++ b/src/hooks/usecamerapostimg.ts
@@ -12,6 +12,7 @@ interface Props {
 // 이미지 경로를 입력받아 base64로 인코딩해서 서버로 전송
 export const useCameraPostImg = ({imagePath, resetImgPath}: Props) => {
   const [response, setResponse] = useState<string>('');
+  const [prevBase64Img, setPrevBase64Img] = useState<string>('');
   const [loading, setLoading] = useState<boolean>(false);
 
   useEffect(() => {
@@ -22,6 +23,7 @@ export const useCameraPostImg = ({imagePath, resetImgPath}: Props) => {
       try {
         setLoading(true);
         const base64Img = await RNFS.readFile(imagePath, 'base64');
+        setPrevBase64Img(`data:image/png;base64,${base64Img}`);
         const postResponse = await axios.post(`${API_URL}/cameraimage`, {
           image: `data:image/png;base64,${base64Img}`,
         });
@@ -57,5 +59,5 @@ export const useCameraPostImg = ({imagePath, resetImgPath}: Props) => {
     console.log('loading: ', loading);
   }, [loading]);
 
-  return {response, setResponse};
+  return {response, setResponse, prevBase64Img};
 };

--- a/src/hooks/usecamerapostimg.ts
+++ b/src/hooks/usecamerapostimg.ts
@@ -1,0 +1,61 @@
+import axios from 'axios';
+import {useEffect, useState} from 'react';
+import RNFS from 'react-native-fs';
+import Sound from 'react-native-sound';
+import {API_URL} from '../utils/apiurl';
+
+interface Props {
+  imagePath: string;
+  resetImgPath: () => void;
+}
+
+// 이미지 경로를 입력받아 base64로 인코딩해서 서버로 전송
+export const useCameraPostImg = ({imagePath, resetImgPath}: Props) => {
+  const [response, setResponse] = useState<string>('');
+  const [loading, setLoading] = useState<boolean>(false);
+
+  useEffect(() => {
+    // 이미지 경로가 비어있거나, 이전 요청이 존재하면 현재 요청을 무시
+    if (imagePath === '' || loading) return;
+
+    const uploadImage = async () => {
+      try {
+        setLoading(true);
+        const base64Img = await RNFS.readFile(imagePath, 'base64');
+        const postResponse = await axios.post(`${API_URL}/cameraimage`, {
+          image: `data:image/png;base64,${base64Img}`,
+        });
+        const {msg, mp3}: {msg: string; mp3: string} = postResponse.data;
+        console.log('msg: ', msg, 'mp3: ', mp3);
+        setResponse(msg);
+
+        const ttsMp3 = new Sound(`${API_URL}${mp3}`, undefined, error => {
+          if (error) {
+            console.log('Error loading sound: ' + error);
+            return;
+          }
+          ttsMp3.play(success => {
+            if (success) {
+              console.log('성공적으로 재생되었습니다.');
+              ttsMp3.release();
+              setLoading(false);
+            } else {
+              console.log('재생 중 오류가 발생했습니다.');
+            }
+          });
+        });
+      } catch (e) {
+        console.error('POST API에서 에러 발생', e);
+      } finally {
+        resetImgPath();
+      }
+    };
+    uploadImage();
+  }, [imagePath]);
+
+  useEffect(() => {
+    console.log('loading: ', loading);
+  }, [loading]);
+
+  return response;
+};

--- a/src/hooks/usecamerapostimg.ts
+++ b/src/hooks/usecamerapostimg.ts
@@ -57,5 +57,5 @@ export const useCameraPostImg = ({imagePath, resetImgPath}: Props) => {
     console.log('loading: ', loading);
   }, [loading]);
 
-  return response;
+  return {response, setResponse};
 };

--- a/src/hooks/usepostimg.ts
+++ b/src/hooks/usepostimg.ts
@@ -1,6 +1,8 @@
 import axios from 'axios';
 import {useEffect, useState} from 'react';
 import RNFS from 'react-native-fs';
+import Sound from 'react-native-sound';
+import {API_URL} from '../utils/apiurl';
 
 interface Props {
   imagePath: string;
@@ -10,7 +12,6 @@ interface Props {
 // 이미지 경로를 입력받아 base64로 인코딩해서 서버로 전송
 export const usePostImg = ({imagePath, resetImgPath}: Props) => {
   const [response, setResponse] = useState<string>('');
-  const [testCnt, setTestCnt] = useState<number>(0);
 
   useEffect(() => {
     if (!imagePath) return;
@@ -18,16 +19,26 @@ export const usePostImg = ({imagePath, resetImgPath}: Props) => {
     const uploadImage = async () => {
       try {
         const base64Img = await RNFS.readFile(imagePath, 'base64');
-        // const res = await axios.post(
-        //   'https://mock_e65979fe955645f187eca0906af61c16.mock.insomnia.rest/postimg',
-        //   {image: base64Img},
-        // );
-        // setResponse(res.data);
-        // Alert.alert('Success', res.data);
-        setTimeout(() => {
-          setResponse('AI의 응답을 받았다 가정 ' + testCnt.toString());
-          setTestCnt(prev => (prev += 1));
-        }, 1000);
+        const postResponse = await axios.post(`${API_URL}/cameraimage`, {
+          image: `data:image/png;base64,${base64Img}`,
+        });
+        const {msg, mp3}: {msg: string; mp3: string} = postResponse.data;
+        console.log('msg: ', msg, 'mp3: ', mp3);
+        setResponse(msg);
+
+        const ttsMp3 = new Sound(`${API_URL}${mp3}`, undefined, error => {
+          if (error) {
+            console.log('Error loading sound: ' + error);
+            return;
+          }
+          ttsMp3.play(success => {
+            if (success) {
+              console.log('성공적으로 재생되었습니다.');
+            } else {
+              console.log('재생 중 오류가 발생했습니다.');
+            }
+          });
+        });
       } catch (e) {
         console.error('POST API에서 에러 발생', e);
       } finally {

--- a/src/hooks/usestt.ts
+++ b/src/hooks/usestt.ts
@@ -5,6 +5,7 @@ import {postSttText} from '../apis/poststttext';
 interface Props {
   isActive: boolean;
   prevAnswer: string;
+  prevBase64Img: string;
   setPrevAnswer: React.Dispatch<React.SetStateAction<string>>;
   volumeBtnState: '' | 'UP' | 'DOWN';
   resetVolumeState: () => void;
@@ -13,6 +14,7 @@ interface Props {
 export const useStt = ({
   isActive,
   prevAnswer,
+  prevBase64Img,
   setPrevAnswer,
   volumeBtnState,
   resetVolumeState,
@@ -42,6 +44,7 @@ export const useStt = ({
             postSttText({
               reqText: recognizedText,
               prevAnswer: prevAnswer,
+              prevBase64Img: prevBase64Img,
               setPrevAnswer: setPrevAnswer,
             });
           })

--- a/src/hooks/usestt.ts
+++ b/src/hooks/usestt.ts
@@ -4,14 +4,21 @@ import {postSttText} from '../apis/poststttext';
 
 interface Props {
   isActive: boolean;
+  prevAnswer: string;
+  setPrevAnswer: React.Dispatch<React.SetStateAction<string>>;
   volumeBtnState: '' | 'UP' | 'DOWN';
   resetVolumeState: () => void;
 }
 
-export const useStt = ({isActive, volumeBtnState, resetVolumeState}: Props) => {
+export const useStt = ({
+  isActive,
+  prevAnswer,
+  setPrevAnswer,
+  volumeBtnState,
+  resetVolumeState,
+}: Props) => {
   const [isRecording, setIsRecording] = useState(false);
   const [recognizedText, setRecognizedText] = useState('');
-  const [aiSttResult, setAiSttResult] = useState<string>('');
 
   useEffect(() => {
     const onSpeechResults = (e: SpeechResultsEvent) => {
@@ -32,7 +39,11 @@ export const useStt = ({isActive, volumeBtnState, resetVolumeState}: Props) => {
         Voice.stop()
           .then(() => {
             setIsRecording(false);
-            postSttText({recognizedText, setAiSttResult});
+            postSttText({
+              reqText: recognizedText,
+              prevAnswer: prevAnswer,
+              setPrevAnswer: setPrevAnswer,
+            });
           })
           .catch(e => {
             console.error('음성인식 종료에 문제 발생: ', e);
@@ -68,5 +79,5 @@ export const useStt = ({isActive, volumeBtnState, resetVolumeState}: Props) => {
     }
   }, [volumeBtnState, isActive]);
 
-  return {recognizedText, aiSttResult, isRecording};
+  return {recognizedText, isRecording};
 };

--- a/src/hooks/usewebviewpostimg.ts
+++ b/src/hooks/usewebviewpostimg.ts
@@ -15,7 +15,12 @@ export const useWebviewPostImg = ({captureImg, resetCaptureImage}: Props) => {
   const [loading, setLoading] = useState<boolean>(false);
 
   useEffect(() => {
-    if (captureImg === '' || loading) return;
+    if (captureImg === '' || loading) {
+      console.log(
+        'captureImg가 비어있거나 loading중이므로 useWebviewPostImg 훅을 early return 합니다.',
+      );
+      return;
+    }
 
     const uploadImage = async () => {
       try {
@@ -62,5 +67,5 @@ export const useWebviewPostImg = ({captureImg, resetCaptureImage}: Props) => {
     console.log('loading: ', loading);
   }, [loading]);
 
-  return response;
+  return {response, setResponse};
 };

--- a/src/hooks/usewebviewpostimg.ts
+++ b/src/hooks/usewebviewpostimg.ts
@@ -13,6 +13,7 @@ interface Props {
 export const useWebviewPostImg = ({captureImg, resetCaptureImage}: Props) => {
   const [response, setResponse] = useState<string>('');
   const [loading, setLoading] = useState<boolean>(false);
+  const [prevBase64Img, setPrevBase64Img] = useState<string>('');
 
   useEffect(() => {
     if (captureImg === '' || loading) {
@@ -26,6 +27,8 @@ export const useWebviewPostImg = ({captureImg, resetCaptureImage}: Props) => {
       try {
         setLoading(true);
         const base64Img = await RNFS.readFile(captureImg, 'base64');
+        setPrevBase64Img(`data:image/png;base64,${base64Img}`);
+
         const postResponse = await axios.post(
           `${API_URL}/webviewimage/totallyblind`,
           {
@@ -67,5 +70,5 @@ export const useWebviewPostImg = ({captureImg, resetCaptureImage}: Props) => {
     console.log('loading: ', loading);
   }, [loading]);
 
-  return {response, setResponse};
+  return {response, setResponse, prevBase64Img};
 };

--- a/src/hooks/usewebviewpostimg.ts
+++ b/src/hooks/usewebviewpostimg.ts
@@ -5,23 +5,28 @@ import Sound from 'react-native-sound';
 import {API_URL} from '../utils/apiurl';
 
 interface Props {
-  imagePath: string;
-  resetImgPath: () => void;
+  captureImg: string;
+  resetCaptureImage: () => void;
 }
 
 // 이미지 경로를 입력받아 base64로 인코딩해서 서버로 전송
-export const usePostImg = ({imagePath, resetImgPath}: Props) => {
+export const useWebviewPostImg = ({captureImg, resetCaptureImage}: Props) => {
   const [response, setResponse] = useState<string>('');
+  const [loading, setLoading] = useState<boolean>(false);
 
   useEffect(() => {
-    if (!imagePath) return;
+    if (captureImg === '' || loading) return;
 
     const uploadImage = async () => {
       try {
-        const base64Img = await RNFS.readFile(imagePath, 'base64');
-        const postResponse = await axios.post(`${API_URL}/cameraimage`, {
-          image: `data:image/png;base64,${base64Img}`,
-        });
+        setLoading(true);
+        const base64Img = await RNFS.readFile(captureImg, 'base64');
+        const postResponse = await axios.post(
+          `${API_URL}/webviewimage/totallyblind`,
+          {
+            image: `data:image/png;base64,${base64Img}`,
+          },
+        );
         const {msg, mp3}: {msg: string; mp3: string} = postResponse.data;
         console.log('msg: ', msg, 'mp3: ', mp3);
         setResponse(msg);
@@ -29,25 +34,33 @@ export const usePostImg = ({imagePath, resetImgPath}: Props) => {
         const ttsMp3 = new Sound(`${API_URL}${mp3}`, undefined, error => {
           if (error) {
             console.log('Error loading sound: ' + error);
+            setLoading(false);
             return;
           }
           ttsMp3.play(success => {
             if (success) {
               console.log('성공적으로 재생되었습니다.');
+              ttsMp3.release();
+              setLoading(false);
             } else {
               console.log('재생 중 오류가 발생했습니다.');
+              setLoading(false);
             }
           });
         });
       } catch (e) {
         console.error('POST API에서 에러 발생', e);
+        setLoading(false);
       } finally {
-        resetImgPath();
+        resetCaptureImage();
       }
     };
-
     uploadImage();
-  }, [imagePath]);
+  }, [captureImg]);
+
+  useEffect(() => {
+    console.log('loading: ', loading);
+  }, [loading]);
 
   return response;
 };

--- a/src/pages/Camerapage.tsx
+++ b/src/pages/Camerapage.tsx
@@ -39,11 +39,16 @@ export default function CameraPage(): React.JSX.Element {
   });
 
   // imagePath가 변하면, 이 이미지를 base64로 인코딩 한 뒤 서버로 post 요청을 하고 결과를 반환하는 훅
-  const aiPhotoRes = useCameraPostImg({imagePath, resetImgPath});
+  const {response: aiPhotoRes, setResponse: setAiPhotoRes} = useCameraPostImg({
+    imagePath,
+    resetImgPath,
+  });
 
   // 볼륨 업버튼 클릭 시 녹음 시작하고, 다시 클릭 시 녹음 종료하는 훅, 서버로 post 요청을 하고 결과도 반환
-  const {recognizedText, aiSttResult, isRecording} = useStt({
+  const {recognizedText, isRecording} = useStt({
     isActive: isCamPageActive,
+    prevAnswer: aiPhotoRes,
+    setPrevAnswer: setAiPhotoRes,
     volumeBtnState: volumeBtnState,
     resetVolumeState: resetVolumeState,
   });
@@ -80,9 +85,6 @@ export default function CameraPage(): React.JSX.Element {
           </Text>
           <Text className="text-custom-black text-xl">
             AI 사진 응답: {aiPhotoRes}
-          </Text>
-          <Text className="text-custom-black text-xl">
-            AI stt 응답: {aiSttResult}
           </Text>
         </View>
       </View>

--- a/src/pages/Camerapage.tsx
+++ b/src/pages/Camerapage.tsx
@@ -39,7 +39,11 @@ export default function CameraPage(): React.JSX.Element {
   });
 
   // imagePath가 변하면, 이 이미지를 base64로 인코딩 한 뒤 서버로 post 요청을 하고 결과를 반환하는 훅
-  const {response: aiPhotoRes, setResponse: setAiPhotoRes} = useCameraPostImg({
+  const {
+    response: aiPhotoRes,
+    setResponse: setAiPhotoRes,
+    prevBase64Img,
+  } = useCameraPostImg({
     imagePath,
     resetImgPath,
   });
@@ -48,6 +52,7 @@ export default function CameraPage(): React.JSX.Element {
   const {recognizedText, isRecording} = useStt({
     isActive: isCamPageActive,
     prevAnswer: aiPhotoRes,
+    prevBase64Img: prevBase64Img,
     setPrevAnswer: setAiPhotoRes,
     volumeBtnState: volumeBtnState,
     resetVolumeState: resetVolumeState,

--- a/src/pages/Camerapage.tsx
+++ b/src/pages/Camerapage.tsx
@@ -12,7 +12,7 @@ import {useVolumeUpDown} from '../hooks/usevolumeupdown';
 import {useStt} from '../hooks/usestt';
 import PermissionComponent from '../components/Permissioncomp';
 import NocamComponent from '../components/Nocamcomp';
-import {usePostImg} from '../hooks/usepostimg';
+import {useCameraPostImg} from '../hooks/usecamerapostimg';
 import Shutter from '../components/Shutter';
 import Record from '../components/Record';
 
@@ -39,7 +39,7 @@ export default function CameraPage(): React.JSX.Element {
   });
 
   // imagePath가 변하면, 이 이미지를 base64로 인코딩 한 뒤 서버로 post 요청을 하고 결과를 반환하는 훅
-  const aiPhotoRes = usePostImg({imagePath, resetImgPath});
+  const aiPhotoRes = useCameraPostImg({imagePath, resetImgPath});
 
   // 볼륨 업버튼 클릭 시 녹음 시작하고, 다시 클릭 시 녹음 종료하는 훅, 서버로 post 요청을 하고 결과도 반환
   const {recognizedText, aiSttResult, isRecording} = useStt({

--- a/src/pages/Camerapage.tsx
+++ b/src/pages/Camerapage.tsx
@@ -20,8 +20,7 @@ export default function CameraPage(): React.JSX.Element {
   const isCamPageActive = useIsFocused();
   const camDevice = useCameraDevice('back');
   const photoFormat = useCameraFormat(camDevice, [
-    {videoResolution: 'max'},
-    {photoResolution: 'max'},
+    {photoResolution: {width: 720, height: 480}},
   ]);
 
   const camRef = useRef<Camera>(null);

--- a/src/pages/Screenshotpage.tsx
+++ b/src/pages/Screenshotpage.tsx
@@ -34,13 +34,17 @@ export default function ScreenshotPage(): React.JSX.Element {
   }, [volumeBtnState]);
 
   // 화면 캡쳐를 감지 -> 스크린샷을 base64로 인코딩해서 서버로 전송 -> 응답 처리하는 훅
-  const {response: aiCaptureResult, setResponse: setAiCaptureResult} =
-    useWebviewPostImg({captureImg, resetCaptureImage});
+  const {
+    response: aiCaptureResult,
+    setResponse: setAiCaptureResult,
+    prevBase64Img: prevBase64Img,
+  } = useWebviewPostImg({captureImg, resetCaptureImage});
 
   // 볼륨 업버튼 클릭 시 녹음 시작하고, 다시 클릭 시 녹음 종료하는 훅, 서버로 post 요청을 하고 결과도 반환
   const {recognizedText, isRecording} = useStt({
     isActive: isWebviewActive,
     prevAnswer: aiCaptureResult,
+    prevBase64Img: prevBase64Img,
     setPrevAnswer: setAiCaptureResult,
     volumeBtnState: volumeBtnState,
     resetVolumeState: resetVolumeState,

--- a/src/pages/Screenshotpage.tsx
+++ b/src/pages/Screenshotpage.tsx
@@ -24,13 +24,6 @@ export default function ScreenshotPage(): React.JSX.Element {
     setIsModalVisible(prev => !prev);
   };
 
-  // 볼륨 업버튼 클릭 시 녹음 시작하고, 다시 클릭 시 녹음 종료하는 훅, 서버로 post 요청을 하고 결과도 반환
-  const {recognizedText, aiSttResult, isRecording} = useStt({
-    isActive: isWebviewActive,
-    volumeBtnState: volumeBtnState,
-    resetVolumeState: resetVolumeState,
-  });
-
   // 볼륨 다운 버튼 클릭 시 화면 캡쳐
   useEffect(() => {
     if (isWebviewActive && volumeBtnState === 'DOWN') {
@@ -41,7 +34,17 @@ export default function ScreenshotPage(): React.JSX.Element {
   }, [volumeBtnState]);
 
   // 화면 캡쳐를 감지 -> 스크린샷을 base64로 인코딩해서 서버로 전송 -> 응답 처리하는 훅
-  const aiCaptureResult = useWebviewPostImg({captureImg, resetCaptureImage});
+  const {response: aiCaptureResult, setResponse: setAiCaptureResult} =
+    useWebviewPostImg({captureImg, resetCaptureImage});
+
+  // 볼륨 업버튼 클릭 시 녹음 시작하고, 다시 클릭 시 녹음 종료하는 훅, 서버로 post 요청을 하고 결과도 반환
+  const {recognizedText, isRecording} = useStt({
+    isActive: isWebviewActive,
+    prevAnswer: aiCaptureResult,
+    setPrevAnswer: setAiCaptureResult,
+    volumeBtnState: volumeBtnState,
+    resetVolumeState: resetVolumeState,
+  });
 
   useEffect(() => {
     console.log('captureImg: ', captureImg);

--- a/src/pages/Uploadimagepage.tsx
+++ b/src/pages/Uploadimagepage.tsx
@@ -1,10 +1,42 @@
-import React from 'react';
-import {Text} from 'react-native';
-
+import React, {useState} from 'react';
+import {Text, View, Image, TouchableOpacity} from 'react-native';
+import ImagePicker from 'react-native-image-crop-picker';
 export default function UploadImagePage(): React.JSX.Element {
+  const [imgBase64, setImgBase64] = useState('');
+
+  const getImage = () => {
+    ImagePicker.openPicker({
+      width: 200,
+      height: 300,
+      cropping: false,
+      includeBase64: true,
+      compressImageQuality: 0.6,
+      mediaType: 'photo',
+    })
+      .then(image => {
+        console.log('selected image name: ', image.filename);
+        setImgBase64(`data:${image.mime};base64,${image.data}`);
+      })
+      .catch(error => {
+        console.log(error);
+      });
+  };
+
   return (
-    <Text className="text-xl text-custom-black">
-      업로드 이미지 페이지 입니다.
-    </Text>
+    <View className="w-full h-full flex justify-center items-center">
+      <Text className="text-xl text-custom-black">
+        업로드 이미지 페이지 입니다.
+      </Text>
+      <Image
+        source={{uri: imgBase64}}
+        resizeMode="center"
+        className="w-48 h-48"
+      />
+      <TouchableOpacity
+        onPress={getImage}
+        className="w-48 p-4 m-4 bg-custom-blue items-center rounded-2xl">
+        <Text className="text-custom-white">이미지 가져오기</Text>
+      </TouchableOpacity>
+    </View>
   );
 }

--- a/src/pages/Uploadimagepage.tsx
+++ b/src/pages/Uploadimagepage.tsx
@@ -4,11 +4,18 @@ import {Text, View, Image, TouchableOpacity} from 'react-native';
 import Sound from 'react-native-sound';
 import ImagePicker from 'react-native-image-crop-picker';
 import {API_URL} from '../utils/apiurl';
+import {useIsFocused} from '@react-navigation/native';
+import {useVolumeUpDown} from '../hooks/usevolumeupdown';
+import {useStt} from '../hooks/usestt';
 
 export default function UploadImagePage(): React.JSX.Element {
+  const isUploadImagePageActive = useIsFocused();
   const [prevBase64Img, setPrevBase64Img] = useState<string>('');
   const [loading, setLoading] = useState<boolean>(false);
   const [aiResponse, setAiResponse] = useState<string>('');
+  const {volumeBtnState, resetVolumeState} = useVolumeUpDown({
+    initialVolume: 0.5,
+  });
 
   const getImage = () => {
     ImagePicker.openPicker({
@@ -61,11 +68,31 @@ export default function UploadImagePage(): React.JSX.Element {
       });
   };
 
+  // 볼륨 업버튼 클릭 시 녹음 시작하고, 다시 클릭 시 녹음 종료하는 훅, 서버로 post 요청을 하고 결과도 반환
+  const {recognizedText, isRecording} = useStt({
+    isActive: isUploadImagePageActive,
+    prevAnswer: aiResponse,
+    prevBase64Img: prevBase64Img,
+    setPrevAnswer: setAiResponse,
+    volumeBtnState: volumeBtnState,
+    resetVolumeState: resetVolumeState,
+  });
+
   return (
     <View className="w-full h-full flex justify-center items-center">
       <Text className="text-xl text-custom-black">
         업로드 이미지 페이지 입니다.
       </Text>
+      <Text className="text-xl text-custom-black">
+        녹음중?: {JSON.stringify(isRecording)}
+      </Text>
+      {isRecording ? (
+        <Text className="text-xl text-custom-black">
+          녹음중: {recognizedText}
+        </Text>
+      ) : (
+        <View />
+      )}
       {prevBase64Img === '' ? (
         <View />
       ) : (

--- a/src/pages/Uploadimagepage.tsx
+++ b/src/pages/Uploadimagepage.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import {Text} from 'react-native';
+
+export default function UploadImagePage(): React.JSX.Element {
+  return (
+    <Text className="text-xl text-custom-black">
+      업로드 이미지 페이지 입니다.
+    </Text>
+  );
+}

--- a/src/pages/Uploadimagepage.tsx
+++ b/src/pages/Uploadimagepage.tsx
@@ -1,21 +1,60 @@
+import axios from 'axios';
 import React, {useState} from 'react';
 import {Text, View, Image, TouchableOpacity} from 'react-native';
+import Sound from 'react-native-sound';
 import ImagePicker from 'react-native-image-crop-picker';
+import {API_URL} from '../utils/apiurl';
+
 export default function UploadImagePage(): React.JSX.Element {
-  const [imgBase64, setImgBase64] = useState('');
+  const [prevBase64Img, setPrevBase64Img] = useState<string>('');
+  const [loading, setLoading] = useState<boolean>(false);
+  const [aiResponse, setAiResponse] = useState<string>('');
 
   const getImage = () => {
     ImagePicker.openPicker({
-      width: 200,
-      height: 300,
+      compressImageMaxWidth: 720,
+      compressImageMaxHeight: 480,
       cropping: false,
       includeBase64: true,
       compressImageQuality: 0.6,
       mediaType: 'photo',
     })
       .then(image => {
+        if (loading) {
+          // 이미지 첨부 후 너무 빠르게 다시 첨부하면, 무시
+          return;
+        }
         console.log('selected image name: ', image.filename);
-        setImgBase64(`data:${image.mime};base64,${image.data}`);
+        setPrevBase64Img(`data:${image.mime};base64,${image.data}`);
+        setLoading(true);
+
+        axios
+          .post(`${API_URL}/webviewimage/totallyblind`, {
+            image: `data:${image.mime};base64,${image.data}`,
+          })
+          .then(res => {
+            const {msg, mp3}: {msg: string; mp3: string} = res.data;
+            console.log('msg: ', msg, 'mp3: ', mp3);
+            setAiResponse(msg);
+
+            const ttsMp3 = new Sound(`${API_URL}${mp3}`, undefined, error => {
+              if (error) {
+                console.log('Error loading sound: ' + error);
+                setLoading(false);
+                return;
+              }
+              ttsMp3.play(success => {
+                if (success) {
+                  console.log('성공적으로 재생되었습니다.');
+                  ttsMp3.release();
+                  setLoading(false);
+                } else {
+                  console.log('재생 중 오류가 발생했습니다.');
+                  setLoading(false);
+                }
+              });
+            });
+          });
       })
       .catch(error => {
         console.log(error);
@@ -27,11 +66,15 @@ export default function UploadImagePage(): React.JSX.Element {
       <Text className="text-xl text-custom-black">
         업로드 이미지 페이지 입니다.
       </Text>
-      <Image
-        source={{uri: imgBase64}}
-        resizeMode="center"
-        className="w-48 h-48"
-      />
+      {prevBase64Img === '' ? (
+        <View />
+      ) : (
+        <Image
+          source={{uri: prevBase64Img}}
+          resizeMode="center"
+          className="w-48 h-48"
+        />
+      )}
       <TouchableOpacity
         onPress={getImage}
         className="w-48 p-4 m-4 bg-custom-blue items-center rounded-2xl">

--- a/src/utils/apiurl.ts
+++ b/src/utils/apiurl.ts
@@ -1,1 +1,1 @@
-export const API_URL = 'https://chsdev.mooo.com/api';
+export const API_URL = 'https://iseeyou.kr.mooo.com';

--- a/src/utils/apiurl.ts
+++ b/src/utils/apiurl.ts
@@ -1,1 +1,1 @@
-export const API_URL = 'https://chsdev.mooo.com/api/';
+export const API_URL = 'https://chsdev.mooo.com/api';

--- a/yarn.lock
+++ b/yarn.lock
@@ -3214,6 +3214,7 @@ __metadata:
     react-native-fs: ^2.20.0
     react-native-safe-area-context: ^4.10.7
     react-native-screens: ^3.32.0
+    react-native-sound: ^0.11.2
     react-native-view-shot: ^3.8.0
     react-native-vision-camera: ^4.4.1
     react-native-volume-manager: ^1.10.0
@@ -8782,6 +8783,15 @@ __metadata:
     react: "*"
     react-native: "*"
   checksum: afcb93e9cd48d5071278213bbc4ddc18112dbdbd16c11e3c7129368614396d8aae13fd70bb299f3c84f52a28e34af06ccdc514de1e97a99f4197069301dab136
+  languageName: node
+  linkType: hard
+
+"react-native-sound@npm:^0.11.2":
+  version: 0.11.2
+  resolution: "react-native-sound@npm:0.11.2"
+  peerDependencies:
+    react-native: ">=0.8.0"
+  checksum: d019de415c5f7bc8af51bc50adff7b9c307cb990aad3ea193933f89df743bbcdbfaa33c4a12bb1143a223137cea39f8b69baf5e1c29f77cf80476616bccc6f91
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3214,6 +3214,7 @@ __metadata:
     react-native-fs: ^2.20.0
     react-native-safe-area-context: ^4.10.7
     react-native-screens: ^3.32.0
+    react-native-view-shot: ^3.8.0
     react-native-vision-camera: ^4.4.1
     react-native-volume-manager: ^1.10.0
     react-native-webview: ^13.10.5
@@ -3740,6 +3741,13 @@ __metadata:
   version: 0.1.0
   resolution: "base-64@npm:0.1.0"
   checksum: 5a42938f82372ab5392cbacc85a5a78115cbbd9dbef9f7540fa47d78763a3a8bd7d598475f0d92341f66285afd377509851a9bb5c67bbecb89686e9255d5b3eb
+  languageName: node
+  linkType: hard
+
+"base64-arraybuffer@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "base64-arraybuffer@npm:1.0.2"
+  checksum: 15e6400d2d028bf18be4ed97702b11418f8f8779fb8c743251c863b726638d52f69571d4cc1843224da7838abef0949c670bde46936663c45ad078e89fee5c62
   languageName: node
   linkType: hard
 
@@ -4347,6 +4355,15 @@ __metadata:
   version: 1.0.0
   resolution: "css-color-keywords@npm:1.0.0"
   checksum: 8f125e3ad477bd03c77b533044bd9e8a6f7c0da52d49bbc0bbe38327b3829d6ba04d368ca49dd9ff3b667d2fc8f1698d891c198bbf8feade1a5501bf5a296408
+  languageName: node
+  linkType: hard
+
+"css-line-break@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "css-line-break@npm:2.1.0"
+  dependencies:
+    utrie: ^1.0.2
+  checksum: 37b1fe632b03be7a287cd394cef8b5285666343443125c510df9cfb6a4734a2c71e154ec8f7bbff72d7c339e1e5872989b1c52d86162aed27d6cc114725bb4d0
   languageName: node
   linkType: hard
 
@@ -5819,6 +5836,16 @@ __metadata:
   version: 2.0.2
   resolution: "html-escaper@npm:2.0.2"
   checksum: d2df2da3ad40ca9ee3a39c5cc6475ef67c8f83c234475f24d8e9ce0dc80a2c82df8e1d6fa78ddd1e9022a586ea1bd247a615e80a5cd9273d90111ddda7d9e974
+  languageName: node
+  linkType: hard
+
+"html2canvas@npm:^1.4.1":
+  version: 1.4.1
+  resolution: "html2canvas@npm:1.4.1"
+  dependencies:
+    css-line-break: ^2.1.0
+    text-segmentation: ^1.0.3
+  checksum: c134324af57f3262eecf982e436a4843fded3c6cf61954440ffd682527e4dd350e0c2fafd217c0b6f9a455fe345d0c67b4505689796ab160d4ca7c91c3766739
   languageName: node
   linkType: hard
 
@@ -8758,6 +8785,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-native-view-shot@npm:^3.8.0":
+  version: 3.8.0
+  resolution: "react-native-view-shot@npm:3.8.0"
+  dependencies:
+    html2canvas: ^1.4.1
+  peerDependencies:
+    react: "*"
+    react-native: "*"
+  checksum: 9e3044da325b44c90238d1eac54ab0a0a9bdab9b7b93f05409e402890c982ee854ae93ff3b6f0d7befe8f2c53df7cf0c708782c007c4c3c4a007a4844b658fde
+  languageName: node
+  linkType: hard
+
 "react-native-vision-camera@npm:^4.4.1":
   version: 4.4.1
   resolution: "react-native-vision-camera@npm:4.4.1"
@@ -9969,6 +10008,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"text-segmentation@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "text-segmentation@npm:1.0.3"
+  dependencies:
+    utrie: ^1.0.2
+  checksum: 2e24632d59567c55ab49ac324815e2f7a8043e63e26b109636322ac3e30692cee8679a448fd5d0f0598a345f407afd0e34ba612e22524cf576d382d84058c013
+  languageName: node
+  linkType: hard
+
 "text-table@npm:^0.2.0":
   version: 0.2.0
   resolution: "text-table@npm:0.2.0"
@@ -10353,6 +10401,15 @@ __metadata:
   version: 1.0.1
   resolution: "utils-merge@npm:1.0.1"
   checksum: c81095493225ecfc28add49c106ca4f09cdf56bc66731aa8dabc2edbbccb1e1bfe2de6a115e5c6a380d3ea166d1636410b62ef216bb07b3feb1cfde1d95d5080
+  languageName: node
+  linkType: hard
+
+"utrie@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "utrie@npm:1.0.2"
+  dependencies:
+    base64-arraybuffer: ^1.0.2
+  checksum: c96fbb7d4d8855a154327da0b18e39b7511cc70a7e4bcc3658e24f424bb884312d72b5ba777500b8858e34d365dc6b1a921dc5ca2f0d341182519c6b78e280a5
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3212,6 +3212,7 @@ __metadata:
     react: 18.2.0
     react-native: 0.74.3
     react-native-fs: ^2.20.0
+    react-native-image-crop-picker: ^0.41.2
     react-native-safe-area-context: ^4.10.7
     react-native-screens: ^3.32.0
     react-native-sound: ^0.11.2
@@ -8760,6 +8761,15 @@ __metadata:
     react-native-windows:
       optional: true
   checksum: 0be9bb9a5c13b501d0a3006efc3aa5c0b5b211456ee04718297f4e522532f3527f1daa220bd67d3b82d819ed8fdab8f64b7d6e0d7b768c1fd1d8ec9122d94316
+  languageName: node
+  linkType: hard
+
+"react-native-image-crop-picker@npm:^0.41.2":
+  version: 0.41.2
+  resolution: "react-native-image-crop-picker@npm:0.41.2"
+  peerDependencies:
+    react-native: ">=0.40.0"
+  checksum: c1333b3b761e948bd0bc856773f68dcc859c7ce39dda3e14d2c32c17d55927735bfc5cbbb7ac5e8bac21feda87c93399f2a596aca7d5b0611cc1e8203d97ad2e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
웹뷰 페이지:
캡쳐 버튼을 누르면 캡쳐됨 -> 캡쳐된 이미지를 Base64로 인코딩해서 백엔드로 전송 
-> 백엔드에서 GPT가 응답 생성 -> 백엔드에서 응답과 TTS 엔드포인트 반환 -> 앱에서 TTS mp3 엔드포인트에 접근해서 TTS 재생

이미지 업로드 페이지:
이미지 업로드 버튼을 누르면 갤러리가 열림 -> 이미지를 선택하는 순간 압축 & Base64로 인코딩해서 백엔드로 전송
-> 백엔드에서 GPT가 응답 생성 -> 백엔드에서 응답과 TTS 엔드포인트 반환 -> 앱에서 TTS mp3 엔드포인트에 접근해서 TTS 재생

두 페이지 모두 처음 이미지로 요청을 받을 때, 요청에 사용한 이미지 base64와 GPT의 응답을 state로 기록해둔다.
기록해둔 이전 답변과 이미지는 음성인식으로 추가 질문을 수행할 때 백엔드로 함께 전송된다.

이전 답변의 경우 이미지와 음성인식 모두 업데이트를 거치고, 이미지의 경우 새로운 이미지를 요청하기 전까지 유지한다.

시간이 남는다면, 각 페이지에서 백엔드와 소통에 사용된 공통 로직을 커스텀 훅이나 함수로 빼주면 유지보수성에 도움될 것 같다.